### PR TITLE
fix compilation error

### DIFF
--- a/groku.go
+++ b/groku.go
@@ -113,7 +113,7 @@ func commands() []cli.Command {
 			Name:  cmd,
 			Usage: cmd,
 			Action: func(c *cli.Context) {
-				http.PostForm(fmt.Sprintf("%vkeypress/%v", findRoku(), c.Command.Name), nil)
+				http.PostForm(fmt.Sprintf("%vkeypress/%v", findRoku(), cmd), nil)
 			},
 		})
 	}


### PR DESCRIPTION
I was getting the following build error
groku.go:116: c.Command undefined (type *cli.Context has no field or method Command)
